### PR TITLE
Add support for long filepaths on Windows

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,14 @@
+{
+	"ImportPath": "github.com/charlievieth/houdini",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v74",
+	"Packages": [
+		"github.com/charlievieth/fs"
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/charlievieth/fs",
+			"Rev": "da68b4db01d67853f09928100b1268dc5ee4f6c7"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/backend.go
+++ b/backend.go
@@ -2,13 +2,13 @@ package houdini
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/charlievieth/fs"
 	"github.com/cloudfoundry-incubator/garden"
 )
 
@@ -36,7 +36,7 @@ func NewBackend(containersDir string) *Backend {
 }
 
 func (backend *Backend) Start() error {
-	return os.MkdirAll(backend.containersDir, 0755)
+	return fs.MkdirAll(backend.containersDir, 0755)
 }
 
 func (backend *Backend) Stop() {
@@ -69,7 +69,7 @@ func (backend *Backend) Create(spec garden.ContainerSpec) (garden.Container, err
 
 	dir := filepath.Join(backend.containersDir, id)
 
-	err := os.MkdirAll(dir, 0755)
+	err := fs.MkdirAll(dir, 0755)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (backend *Backend) Destroy(handle string) error {
 		return err
 	}
 
-	err = os.RemoveAll(container.workDir)
+	err = fs.RemoveAll(container.workDir)
 	if err != nil {
 		return err
 	}

--- a/container.go
+++ b/container.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/charlievieth/fs"
 	"github.com/cloudfoundry-incubator/garden"
 	"github.com/pivotal-golang/archiver/compressor"
 	"github.com/vito/houdini/process"
@@ -71,7 +72,7 @@ func (container *container) Info() (garden.ContainerInfo, error) { return garden
 func (container *container) StreamIn(spec garden.StreamInSpec) error {
 	finalDestination := filepath.Join(container.workDir, filepath.FromSlash(spec.Path))
 
-	err := os.MkdirAll(finalDestination, 0755)
+	err := fs.MkdirAll(finalDestination, 0755)
 	if err != nil {
 		return err
 	}
@@ -252,21 +253,21 @@ func extractTarArchiveFile(header *tar.Header, dest string, input io.Reader) err
 	fileInfo := header.FileInfo()
 
 	if fileInfo.IsDir() {
-		err := os.MkdirAll(filePath, fileInfo.Mode())
+		err := fs.MkdirAll(filePath, fileInfo.Mode())
 		if err != nil {
 			return err
 		}
 	} else {
-		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		err := fs.MkdirAll(filepath.Dir(filePath), 0755)
 		if err != nil {
 			return err
 		}
 
 		if fileInfo.Mode()&os.ModeSymlink != 0 {
-			return os.Symlink(header.Linkname, filePath)
+			return fs.Symlink(header.Linkname, filePath)
 		}
 
-		fileCopy, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileInfo.Mode())
+		fileCopy, err := fs.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileInfo.Mode())
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/charlievieth/fs/LICENSE
+++ b/vendor/github.com/charlievieth/fs/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Charlie Vieth
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/charlievieth/fs/fs.go
+++ b/vendor/github.com/charlievieth/fs/fs.go
@@ -1,0 +1,180 @@
+package fs
+
+import (
+	"os"
+	"time"
+)
+
+/*
+  The below code contains portions of the Go standard library, specically
+  the os package.
+
+  Copyright (c) 2009 The Go Authors. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of Google Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Chdir changes the current working directory to the named directory.
+// If there is an error, it will be of type *PathError.
+func Chdir(dir string) error {
+	return chdir(dir)
+}
+
+// Chmod changes the mode of the named file to mode.
+// If the file is a symbolic link, it changes the mode of the link's target.
+// If there is an error, it will be of type *PathError.
+func Chmod(name string, mode os.FileMode) error {
+	return chmod(name, mode)
+}
+
+// Chown changes the numeric uid and gid of the named file.
+// If the file is a symbolic link, it changes the uid and gid of the link's target.
+// If there is an error, it will be of type *PathError.
+func Chown(name string, uid, gid int) error {
+	return chown(name, uid, gid)
+}
+
+// Chtimes changes the access and modification times of the named
+// file, similar to the Unix utime() or utimes() functions.
+//
+// The underlying filesystem may truncate or round the values to a
+// less precise time unit.
+// If there is an error, it will be of type *PathError.
+func Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return chtimes(name, atime, mtime)
+}
+
+// Lchown changes the numeric uid and gid of the named file.
+// If the file is a symbolic link, it changes the uid and gid of the link itself.
+// If there is an error, it will be of type *PathError.
+func Lchown(name string, uid, gid int) error {
+	return lchown(name, uid, gid)
+}
+
+// Link creates newname as a hard link to the oldname file.
+// If there is an error, it will be of type *LinkError.
+func Link(oldname, newname string) error {
+	return link(oldname, newname)
+}
+
+// Mkdir creates a new directory with the specified name and permission bits.
+// If there is an error, it will be of type *PathError.
+func Mkdir(name string, perm os.FileMode) error {
+	return mkdir(name, perm)
+}
+
+// MkdirAll creates a directory named path,
+// along with any necessary parents, and returns nil,
+// or else returns an error.
+// The permission bits perm are used for all
+// directories that MkdirAll creates.
+// If path is already a directory, MkdirAll does nothing
+// and returns nil.
+func MkdirAll(path string, perm os.FileMode) error {
+	return mkdirall(path, perm)
+}
+
+// Readlink returns the destination of the named symbolic link.
+// If there is an error, it will be of type *PathError.
+func Readlink(name string) (string, error) {
+	return readlink(name)
+}
+
+// Remove removes the named file or directory.
+// If there is an error, it will be of type *PathError.
+func Remove(name string) error {
+	return remove(name)
+}
+
+// RemoveAll removes path and any children it contains.
+// It removes everything it can but returns the first error
+// it encounters.  If the path does not exist, RemoveAll
+// returns nil (no error).
+func RemoveAll(path string) error {
+	return removeall(path)
+}
+
+// Rename renames (moves) a file. OS-specific restrictions might apply.
+// If there is an error, it will be of type *LinkError.
+func Rename(oldpath, newpath string) error {
+	return rename(oldpath, newpath)
+}
+
+// Symlink creates newname as a symbolic link to oldname.
+// If there is an error, it will be of type *LinkError.
+func Symlink(oldname, newname string) error {
+	return symlink(oldname, newname)
+}
+
+// File
+
+// Create creates the named file with mode 0666 (before umask), truncating
+// it if it already exists. If successful, methods on the returned
+// File can be used for I/O; the associated file descriptor has mode
+// O_RDWR.
+// If there is an error, it will be of type *PathError.
+func Create(name string) (*os.File, error) {
+	return create(name)
+}
+
+// NewFile returns a new File with the given file descriptor and name.
+func NewFile(fd uintptr, name string) *os.File {
+	return newfile(fd, name)
+}
+
+// Open opens the named file for reading.  If successful, methods on
+// the returned file can be used for reading; the associated file
+// descriptor has mode O_RDONLY.
+// If there is an error, it will be of type *PathError.
+func Open(name string) (*os.File, error) {
+	return open(name)
+}
+
+// OpenFile is the generalized open call; most users will use Open
+// or Create instead.  It opens the named file with specified flag
+// (O_RDONLY etc.) and perm, (0666 etc.) if applicable.  If successful,
+// methods on the returned File can be used for I/O.
+// If there is an error, it will be of type *PathError.
+func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return openfile(name, flag, perm)
+}
+
+// FileInfo
+
+// Lstat returns a FileInfo describing the named file.
+// If the file is a symbolic link, the returned FileInfo
+// describes the symbolic link.  Lstat makes no attempt to follow the link.
+// If there is an error, it will be of type *PathError.
+func Lstat(name string) (os.FileInfo, error) {
+	return lstat(name)
+}
+
+// Stat returns a FileInfo describing the named file.
+// If there is an error, it will be of type *PathError.
+func Stat(name string) (os.FileInfo, error) {
+	return stat(name)
+}

--- a/vendor/github.com/charlievieth/fs/fs_unix.go
+++ b/vendor/github.com/charlievieth/fs/fs_unix.go
@@ -1,0 +1,84 @@
+// +build !windows
+
+package fs
+
+import (
+	"os"
+	"time"
+)
+
+func chdir(dir string) error {
+	return os.Chdir(dir)
+}
+
+func chmod(name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
+func chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
+}
+
+func chtimes(name string, atime time.Time, mtime time.Time) error {
+	return os.Chtimes(name, atime, mtime)
+}
+
+func lchown(name string, uid, gid int) error {
+	return os.Lchown(name, uid, gid)
+}
+
+func link(oldname, newname string) error {
+	return os.Link(oldname, newname)
+}
+
+func mkdir(name string, perm os.FileMode) error {
+	return os.Mkdir(name, perm)
+}
+
+func mkdirall(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func readlink(name string) (string, error) {
+	return os.Readlink(name)
+}
+
+func remove(name string) error {
+	return os.Remove(name)
+}
+
+func removeall(path string) error {
+	return os.RemoveAll(path)
+}
+
+func rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
+func create(name string) (*os.File, error) {
+	return os.Create(name)
+}
+
+func newfile(fd uintptr, name string) *os.File {
+	return os.NewFile(fd, name)
+}
+
+func open(name string) (*os.File, error) {
+	return os.Open(name)
+}
+
+func openfile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+func lstat(name string) (os.FileInfo, error) {
+	return os.Lstat(name)
+}
+
+func stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}

--- a/vendor/github.com/charlievieth/fs/fs_windows.go
+++ b/vendor/github.com/charlievieth/fs/fs_windows.go
@@ -1,0 +1,221 @@
+package fs
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+func absPath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(wd, path), nil
+}
+
+func winPath(path string) (string, error) {
+	p, err := absPath(path)
+	if err != nil {
+		return "", err
+	}
+	switch n := len(p); {
+	case n >= syscall.MAX_LONG_PATH:
+		err := &os.PathError{
+			Op:   "fs: Path",
+			Path: path,
+			Err:  errors.New("path length exceeds MAX_LONG_PATH"),
+		}
+		return "", err
+	case n >= syscall.MAX_PATH:
+		return `\\?\` + p, nil
+	default:
+		return path, nil
+	}
+}
+
+func newPathError(op, path string, err error) error {
+	return &os.PathError{
+		Op:   "fs: " + op,
+		Path: path,
+		Err:  err,
+	}
+}
+
+func newLinkError(op, oldname, newname string, err error) error {
+	return &os.LinkError{
+		Op:  "fs: " + op,
+		Old: oldname,
+		New: newname,
+		Err: err,
+	}
+}
+
+func chdir(dir string) error {
+	p, err := winPath(dir)
+	if err != nil {
+		return newPathError("chdir", dir, err)
+	}
+	return os.Chdir(p)
+}
+
+func chmod(name string, mode os.FileMode) error {
+	p, err := winPath(name)
+	if err != nil {
+		return newPathError("chmod", name, err)
+	}
+	return os.Chmod(p, mode)
+}
+
+func chown(name string, uid, gid int) error {
+	p, err := winPath(name)
+	if err != nil {
+		return newPathError("chown", name, err)
+	}
+	return os.Chown(p, uid, gid)
+}
+
+func chtimes(name string, atime time.Time, mtime time.Time) error {
+	p, err := winPath(name)
+	if err != nil {
+		return newPathError("chtimes", name, err)
+	}
+	return os.Chtimes(p, atime, mtime)
+}
+
+func lchown(name string, uid, gid int) error {
+	p, err := winPath(name)
+	if err != nil {
+		return newPathError("lchown", name, err)
+	}
+	return os.Lchown(p, uid, gid)
+}
+
+func link(oldname, newname string) error {
+	op, err := winPath(oldname)
+	if err != nil {
+		return newLinkError("link", oldname, newname, err)
+	}
+	np, err := winPath(newname)
+	if err != nil {
+		return newLinkError("link", oldname, newname, err)
+	}
+	return os.Link(op, np)
+}
+
+func mkdir(name string, perm os.FileMode) error {
+	p, err := winPath(name)
+	if err != nil {
+		return newPathError("mkdir", name, err)
+	}
+	return os.Mkdir(p, perm)
+}
+
+func mkdirall(path string, perm os.FileMode) error {
+	p, err := winPath(path)
+	if err != nil {
+		return err
+	}
+	return os.MkdirAll(p, perm)
+}
+
+func readlink(name string) (string, error) {
+	p, err := winPath(name)
+	if err != nil {
+		return "", newPathError("readlink", name, err)
+	}
+	return os.Readlink(p)
+}
+
+func remove(name string) error {
+	p, err := winPath(name)
+	if err != nil {
+		return newPathError("remove", name, err)
+	}
+	return os.Remove(p)
+}
+
+func removeall(path string) error {
+	p, err := winPath(path)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(p)
+}
+
+func rename(oldpath, newpath string) error {
+	op, err := winPath(oldpath)
+	if err != nil {
+		return newLinkError("rename", oldpath, newpath, err)
+	}
+	np, err := winPath(newpath)
+	if err != nil {
+		return newLinkError("rename", oldpath, newpath, err)
+	}
+	return os.Rename(op, np)
+}
+
+func symlink(oldname, newname string) error {
+	op, err := winPath(oldname)
+	if err != nil {
+		return newLinkError("symlink", oldname, newname, err)
+	}
+	np, err := winPath(newname)
+	if err != nil {
+		return newLinkError("symlink", oldname, newname, err)
+	}
+	return os.Symlink(op, np)
+}
+
+func create(name string) (*os.File, error) {
+	p, err := winPath(name)
+	if err != nil {
+		return nil, newPathError("create", name, err)
+	}
+	return os.Create(p)
+}
+
+func newfile(fd uintptr, name string) *os.File {
+	p, err := winPath(name)
+	if err != nil {
+		return os.NewFile(fd, name)
+	}
+	return os.NewFile(fd, p)
+}
+
+func open(name string) (*os.File, error) {
+	p, err := winPath(name)
+	if err != nil {
+		return nil, newPathError("open", name, err)
+	}
+	return os.Open(p)
+}
+
+func openfile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	p, err := winPath(name)
+	if err != nil {
+		return nil, newPathError("openfile", name, err)
+	}
+	return os.OpenFile(p, flag, perm)
+}
+
+func lstat(name string) (os.FileInfo, error) {
+	p, err := winPath(name)
+	if err != nil {
+		return nil, newPathError("lstat", name, err)
+	}
+	return os.Lstat(p)
+}
+
+func stat(name string) (os.FileInfo, error) {
+	p, err := winPath(name)
+	if err != nil {
+		return nil, newPathError("stat", name, err)
+	}
+	return os.Stat(p)
+}


### PR DESCRIPTION
This commit uses the [fs](https://github.com/charlievieth/fs) package to add support for filepaths greater than MAX_PATH on Windows.

[#121239765]
