### PR TITLE
Add Solaris support

### DIFF
--- a/process/spawn.go
+++ b/process/spawn.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 
 	"github.com/cloudfoundry-incubator/garden"
-	"github.com/kr/pty"
 	"github.com/vito/houdini/ptyutil"
+	"github.com/pkg/term/termios"
 )
 
 func spawn(cmd *exec.Cmd, ttySpec *garden.TTYSpec, stdout io.Writer, stderr io.Writer) (process, io.WriteCloser, error) {
@@ -20,7 +20,7 @@ func spawn(cmd *exec.Cmd, ttySpec *garden.TTYSpec, stdout io.Writer, stderr io.W
 	var processPty *os.File
 
 	if ttySpec != nil {
-		pty, tty, err := pty.Open()
+		pty, tty, err := termios.Pty()
 		if err != nil {
 			return nil, nil, err
 		}

--- a/ptyutil/winsize.go
+++ b/ptyutil/winsize.go
@@ -1,3 +1,5 @@
+// +build !solaris
+
 package ptyutil
 
 import (

--- a/ptyutil/winsize_solaris.go
+++ b/ptyutil/winsize_solaris.go
@@ -1,0 +1,21 @@
+package ptyutil
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+type ttySize struct {
+	Rows   uint16
+	Cols   uint16
+	Xpixel uint16
+	Ypixel uint16
+}
+
+func SetWinSize(f *os.File, cols int, rows int) error {
+	return unix.IoctlSetInt(int(f.Fd()), int(syscall.TIOCSWINSZ),
+		int(uintptr(unsafe.Pointer(&ttySize{uint16(rows), uint16(cols), 0, 0}))))
+}


### PR DESCRIPTION
Hi; please consider this pull request to add Solaris support.

I've removed use of the `github.com/kr/pty` package in favor of just straight up `golang.org/x/sys` (`kr/pty`  already depends on `x/sys`). One reason for this is that I've had to add Solaris support to `x/sys` already, so keeping `kr/pty` here would require also adding Solaris support to that package. Just a bit less Yak shaving.
